### PR TITLE
feat(new): make opener opt-in after creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ wto list
 ```sh
 wto new
 wto new feature/my-task
+wto new feature/my-task --open system
 ```
 
 3. Open an existing worktree:
@@ -135,12 +136,12 @@ Default behavior:
 - Runs `git worktree prune --expire now`, then `git fetch origin --prune`
 - Uses `main` as base when creating a new branch
 - Creates worktrees under `<repo-parent>/worktrees/<branch>`
-- Opens the new worktree with `system` in a new window
+- Does not open the created worktree unless `--open` is explicitly set
 
 Main options:
 
 - `--base <branch>`
-- `--open system|vscode|cursor|vim`
+- `--open none|system|vscode|cursor|vim`
 
 ### `wto open`
 
@@ -216,6 +217,11 @@ Config precedence:
 ```text
 flag > repo (.wtoconfig.json) > global (config.json) > built-in defaults
 ```
+
+Note:
+
+- `open.default` is used by `wto open`
+- `wto new` does not auto-open unless you set `--open`
 
 Config file locations:
 

--- a/internal/cli/new.go
+++ b/internal/cli/new.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	defaultBaseBranch = config.DefaultBaseBranch
+	newOpenNone       = "none"
 )
 
 func newNewCmd(deps Dependencies) *cobra.Command {
@@ -24,7 +25,7 @@ func newNewCmd(deps Dependencies) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "new [branch]",
-		Short: "Create and open a new worktree",
+		Short: "Create a new worktree",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := deps.Git.WorktreePrune(cmd.Context()); err != nil {
@@ -47,17 +48,11 @@ func newNewCmd(deps Dependencies) *cobra.Command {
 				return fmt.Errorf("base branch is empty. Set --base or `baseBranch` in config to a valid branch and retry")
 			}
 
-			resolvedOpener := strings.TrimSpace(openerName)
-			if !cmd.Flags().Changed("open") {
-				resolvedOpener = cfg.Open.Default
-			}
-			if err := validateExplicitOpenerAvailability(cmd, deps.LookPath, resolvedOpener); err != nil {
-				return err
-			}
-
-			windowMode, err := opener.ParseWindowMode(cfg.Open.Window)
-			if err != nil {
-				return fmt.Errorf("invalid config open.window value: %w", err)
+			resolvedOpener := strings.ToLower(strings.TrimSpace(openerName))
+			if resolvedOpener != newOpenNone {
+				if err := validateExplicitOpenerAvailability(cmd, deps.LookPath, resolvedOpener); err != nil {
+					return err
+				}
 			}
 
 			targetBranch := ""
@@ -117,8 +112,15 @@ func newNewCmd(deps Dependencies) *cobra.Command {
 				return err
 			}
 
-			if err := deps.Opener.Open(cmd.Context(), resolvedOpener, worktreePath, windowMode); err != nil {
-				return err
+			if resolvedOpener != newOpenNone {
+				windowMode, err := opener.ParseWindowMode(cfg.Open.Window)
+				if err != nil {
+					return fmt.Errorf("invalid config open.window value: %w", err)
+				}
+
+				if err := deps.Opener.Open(cmd.Context(), resolvedOpener, worktreePath, windowMode); err != nil {
+					return err
+				}
 			}
 
 			return nil
@@ -126,7 +128,7 @@ func newNewCmd(deps Dependencies) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&baseBranch, "base", defaultBaseBranch, "base branch used when creating a new branch")
-	cmd.Flags().StringVar(&openerName, "open", config.DefaultOpenKind, "opener to use: "+config.SupportedOpenKindsText)
+	cmd.Flags().StringVar(&openerName, "open", newOpenNone, "opener to use after creation: none|"+config.SupportedOpenKindsText)
 
 	return cmd
 }

--- a/internal/cli/new_test.go
+++ b/internal/cli/new_test.go
@@ -115,6 +115,9 @@ func TestNewCommand_UsesRemoteBranchAsStartPoint(t *testing.T) {
 	if got := gitClient.worktreeAddCalls[0].StartPoint; got != "origin/feature/remote" {
 		t.Fatalf("unexpected start point: %q", got)
 	}
+	if openExec.call != 0 {
+		t.Fatalf("opener should not be called by default, got %d", openExec.call)
+	}
 }
 
 func TestNewCommand_ReturnsErrorWhenExplicitVSCodeIsUnavailable(t *testing.T) {
@@ -463,7 +466,7 @@ func TestNewCommand_DoesNotValidateExistingBranchSelection(t *testing.T) {
 	}
 }
 
-func TestNewCommand_UsesConfigDefaultsWhenFlagsAreNotProvided(t *testing.T) {
+func TestNewCommand_DoesNotOpenByDefaultWhenFlagsAreNotProvided(t *testing.T) {
 	t.Parallel()
 
 	repoRoot := createTestRepoRoot(t)
@@ -519,11 +522,8 @@ func TestNewCommand_UsesConfigDefaultsWhenFlagsAreNotProvided(t *testing.T) {
 	if got := filepath.Clean(gitClient.worktreeAddCalls[0].Path); got != expectedPath {
 		t.Fatalf("unexpected worktree path: want=%q got=%q", expectedPath, got)
 	}
-	if openExec.kind != "cursor" {
-		t.Fatalf("unexpected opener kind: %q", openExec.kind)
-	}
-	if openExec.window != openerpkg.WindowReuse {
-		t.Fatalf("unexpected window mode: %q", openExec.window)
+	if openExec.call != 0 {
+		t.Fatalf("opener should not be called by default, got %d", openExec.call)
 	}
 }
 


### PR DESCRIPTION
## Summary\n- make wto new not auto-open by default\n- keep opener behavior opt-in via --open\n- update tests and README to reflect the new default\n\n## Verification\n- go test ./...